### PR TITLE
Enhance mapepire-js documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,10 @@
 {
-  "name": "Mapepire-IBMi",
+  "name": "Mapepire-IBMi.github.io",
   "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Mapepire-IBMi",
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.5.10",

--- a/src/content/docs/guides/Runtimes/nodejs.md
+++ b/src/content/docs/guides/Runtimes/nodejs.md
@@ -17,7 +17,11 @@ This document illustrates the use of the mapepire-js client. Other language clie
 
 ### Specifying the mapepire-server instance for the connection
 
-The location and port of the mapepire-server instance as well as the credentials for IBM i Db2 can be specified in a `.env` file. Copy the `.env.sample` file in the root directory of mapepire-js to `.env` and fill in the values.
+The location and port of the mapepire-server instance as well as the credentials for IBM i Db2 can be specified in a `.env` file. Copy the `.env.sample` file in the root directory of mapepire-js to `.env` and fill in the values. Note that any entry in the `.env` file containing javascript metacharacters such as `$` may need to be backslash-escaped , e.g.,
+
+```sh
+VITE_DB_PASS=MYPAS\$WORD
+```
 
 #### SSH port redirection for connections through firewall to remote mapepire-server
 

--- a/src/content/docs/guides/Runtimes/nodejs.md
+++ b/src/content/docs/guides/Runtimes/nodejs.md
@@ -17,11 +17,7 @@ This document illustrates the use of the mapepire-js client. Other language clie
 
 ### Specifying the mapepire-server instance for the connection
 
-The mapepire-server instance can run natively on the IBM i Db2 host, or can run on any suitable Node.js platform and connect remotely to an IBM i Db2 host.
-
-The location and port of the mapepire-server instance is specified in a `.env` file. Copy the `.env.sample` file in the root directory of mapepire-js to `.env` and fill in the values for the connection to the mapepire-server instance.
-
-The credentials used for the connection from the mapepire-server instance to the IBM i Db2 host are described below.
+The location and port of the mapepire-server instance as well as the credentials for IBM i Db2 can be specified in a `.env` file. Copy the `.env.sample` file in the root directory of mapepire-js to `.env` and fill in the values.
 
 #### SSH port redirection for connections through firewall to remote mapepire-server
 

--- a/src/content/docs/guides/Runtimes/nodejs.md
+++ b/src/content/docs/guides/Runtimes/nodejs.md
@@ -9,6 +9,40 @@ Using Db2 for IBM i with Node.js is easy. First, install the package:
 npm i @ibm/mapepire-js
 ```
 
+## Basic architecture
+
+mapepire-js is a pooling asynchronous client to an instance of the [mapepire-server](https://github.com/Mapepire-IBMi/mapepire-server). The mapepire-server authorizes and mediates connections to an IBM i Db2 server on behalf of the client.
+
+This document illustrates the use of the mapepire-js client. Other language clients and the mapepire-server itself are documented elsewhere.
+
+### Specifying the mapepire-server instance for the connection
+
+The mapepire-server instance can run natively on the IBM i Db2 host, or can run on any suitable Node.js platform and connect remotely to an IBM i Db2 host.
+
+The location and port of the mapepire-server instance is specified in a `.env` file. Copy the `.env.sample` file in the root directory of mapepire-js to `.env` and fill in the values for the connection to the mapepire-server instance.
+
+The credentials used for the connection from the mapepire-server instance to the IBM i Db2 host are described below.
+
+#### SSH port redirection for connections through firewall to remote mapepire-server
+
+When mapepire-js runs on a workstation and connects to mapepire-server running on a remote host that is firewalled, you can use Secure Shell (SSH) port redirection as a means to connect through the firewall.
+
+Assuming maprepire-server is running on port 8076 on `myserver.mybiz.com` and appears on that server's `localhost` TCP/IP interface, you can redirect the remote 8076 port to a local port (let's say, 8081 on `localhost`) as follows:
+
+```sh
+ssh -L8081:localhost:8076 -l myuserid myserver.mybiz.com
+```
+
+The "localhost" bind specification here refers to the `localhost` interface on the server side. The "localhost" bind specification for the local workstation is implicit in the absence of a bind address specification preceding the local port number. [(See the OpenSSH manual for the `ssh` comand)](https://man.openbsd.org/ssh).
+
+If mapepire-server only appears on the public interface of the remote server, try:
+
+```sh
+ssh -L8081:myserver.mybiz.com:8076 -l myuserid myserver.mybiz.com
+```
+
+In either case, the workstation localhost port 8081 will be a redirect to the remote server's port 8076.
+
 ### Simple test
 
 Credentials belong in an object which can be passed to a `Pool` or `SQLJob`.

--- a/src/content/docs/guides/Runtimes/nodejs.md
+++ b/src/content/docs/guides/Runtimes/nodejs.md
@@ -23,26 +23,6 @@ The location and port of the mapepire-server instance as well as the credentials
 VITE_DB_PASS=MYPAS\$WORD
 ```
 
-#### SSH port redirection for connections through firewall to remote mapepire-server
-
-When mapepire-js runs on a workstation and connects to mapepire-server running on a remote host that is firewalled, you can use Secure Shell (SSH) port redirection as a means to connect through the firewall.
-
-Assuming maprepire-server is running on port 8076 on `myserver.mybiz.com` and appears on that server's `localhost` TCP/IP interface, you can redirect the remote 8076 port to a local port (let's say, 8081 on `localhost`) as follows:
-
-```sh
-ssh -L8081:localhost:8076 -l myuserid myserver.mybiz.com
-```
-
-The "localhost" bind specification here refers to the `localhost` interface on the server side. The "localhost" bind specification for the local workstation is implicit in the absence of a bind address specification preceding the local port number. [(See the OpenSSH manual for the `ssh` comand)](https://man.openbsd.org/ssh).
-
-If mapepire-server only appears on the public interface of the remote server, try:
-
-```sh
-ssh -L8081:myserver.mybiz.com:8076 -l myuserid myserver.mybiz.com
-```
-
-In either case, the workstation localhost port 8081 will be a redirect to the remote server's port 8076.
-
 ### Simple test
 
 Credentials belong in an object which can be passed to a `Pool` or `SQLJob`.

--- a/src/content/docs/guides/usernotes/ssh_redirect.md
+++ b/src/content/docs/guides/usernotes/ssh_redirect.md
@@ -1,0 +1,19 @@
+# SSH port redirection for connections through firewall to remote mapepire-server
+
+When mapepire-js runs on a workstation and connects to mapepire-server running on a remote host that is firewalled, you can use Secure Shell (SSH) port redirection as a means to connect through the firewall.
+
+Assuming maprepire-server is running on port 8076 on `myserver.mybiz.com` and appears on that server's `localhost` TCP/IP interface, you can redirect the remote 8076 port to a local port (let's say, 8081 on `localhost`) as follows:
+
+```sh
+ssh -L8081:localhost:8076 -l myuserid myserver.mybiz.com
+```
+
+The "localhost" bind specification here refers to the `localhost` interface on the server side. The "localhost" bind specification for the local workstation is implicit in the absence of a bind address specification preceding the local port number. [(See the OpenSSH manual for the `ssh` comand)](https://man.openbsd.org/ssh).
+
+If mapepire-server only appears on the public interface of the remote server, try:
+
+```sh
+ssh -L8081:myserver.mybiz.com:8076 -l myuserid myserver.mybiz.com
+```
+
+In either case, the workstation localhost port 8081 will be a redirect to the remote server's port 8076.


### PR DESCRIPTION
- document aspects of the mapepire-js client and its relation to the mapepire-server and IBM i Db2
- describe connecting from the client to the server using ssh port redirection