### PR TITLE
Add Java client docs

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,7 +7,7 @@ export default defineConfig({
 		starlight({
 			title: 'Mapepire',
 			social: {
-				github: 'https://github.com/withastro/starlight',
+				github: 'https://github.com/Mapepire-IBMi',
 			},
 			sidebar: [
 				{

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,9 @@ export default defineConfig({
 					collapsed: true,
 				},
 			],
+			tableOfContents: {
+				maxHeadingLevel: 4
+			}
 		}),
 	],
 });

--- a/src/content/docs/guides/Clients.md
+++ b/src/content/docs/guides/Clients.md
@@ -8,11 +8,11 @@ sidebar:
 We provide clients for a few runtimes thus far, with more planned in the future. Select your runtime/language below for a guide to get started with it.
 
 * [Python]() - *Adam Shedivy, IBM*
-* [Node.js](/guides/Clients/nodejs) - *Jonathan Zak, IBM*
-* [Java]() - *Sanjula Ganepola, IBM*
+* [Node.js](/guides/usage/nodejs) - *Jonathan Zak, IBM*
+* [Java](/guides/usage/java) - *Sanjula Ganepola, IBM*
 * [C#/.NET Core] - *Mark Goff, IBM*
-* [PHP] - tbd
-* [Go] - tbh
+* [PHP] - TBD
+* [Go] - TBD
 
 
 ### App examples

--- a/src/content/docs/guides/Usage/java.md
+++ b/src/content/docs/guides/Usage/java.md
@@ -65,9 +65,9 @@ query.close().get();
 job.close();
 ```
 
-#### SQL Prepared Statements 
+#### Prepared Statements 
 
-SQL statements can be easily prepared and executed with parameters:
+Statements can be easily prepared and executed with parameters:
 
 ```java
 QueryOptions options = new QueryOptions(false, false, Arrays.asList("TABLE_NAME", "LONG_COMMENT", "CONSTRAINT_NAME"));

--- a/src/content/docs/guides/Usage/java.md
+++ b/src/content/docs/guides/Usage/java.md
@@ -21,7 +21,7 @@ Using DB2 for IBM i with Java is now easy with the help of the `mapepire-java` c
 
 ### Specifying the `mapepire-server` Instance for the Connection
 
-The location and port of the `mapepire-server` instance as well as the credentials for IBM i Db2 can be specified in a `config.properties` file. Copy the [`config.properties.sample`](https://github.com/Mapepire-IBMi/java/simple-app/src/main/resources/config.properties.sample) file from the `simple-app` demo project to `config.properties` and fill in the credentials.
+The location and port of the `mapepire-server` instance as well as the credentials for IBM i Db2 can be specified in a `config.properties` file. Copy the [`config.properties.sample`](https://github.com/Mapepire-IBMi/java/simple-app/src/main/resources/config.properties.sample) file from the [simple-app](https://github.com/Mapepire-IBMi/java/simple-app) demo project to `config.properties` and fill in the credentials.
 
 The following function can be used to construct a `DaemonServer` object with the credentials you just specified. This object will be passed to a `SqlJob` or `Pool` object.
 

--- a/src/content/docs/guides/Usage/java.md
+++ b/src/content/docs/guides/Usage/java.md
@@ -19,7 +19,7 @@ Using DB2 for IBM i with Java is now easy with the help of the `mapepire-java` c
 
 * Java 8 or later
 
-### Specifying the `mapepire-server` Instance for the Connection
+## Specifying the `mapepire-server` Instance for the Connection
 
 The location and port of the `mapepire-server` instance as well as the credentials for IBM i Db2 can be specified in a `config.properties` file. Copy the [`config.properties.sample`](https://github.com/Mapepire-IBMi/java/simple-app/src/main/resources/config.properties.sample) file from the [simple-app](https://github.com/Mapepire-IBMi/java/simple-app) demo project to `config.properties` and fill in the credentials.
 
@@ -46,7 +46,7 @@ private static DaemonServer getDaemonServer() throws IOException {
 }
 ```
 
-### Running Queries
+## Running Queries
 
 The core APIs lie in the `SqlJob` and `Query` classes which are what give you the ability to execute queries.
 
@@ -65,7 +65,7 @@ query.close().get();
 job.close();
 ```
 
-#### Prepared Statements 
+### Prepared Statements 
 
 Statements can be easily prepared and executed with parameters:
 
@@ -75,7 +75,7 @@ Query<Object> query = job.query("SELECT * FROM SAMPLE.SYSCOLUMNS WHERE COLUMN_NA
 QueryResult<Object> result = query.execute(30).get();
 ```
 
-#### CL Commands
+### CL Commands
 
 CL commands can be easily run by setting the `isClCommand` option to be `true` on the `QueryOptions` object or by directly using the `clCommand` API on a job:
 
@@ -84,7 +84,7 @@ Query<Object> query = job.clCommand("CRTLIB LIB(MYLIB1) TEXT('My cool library')"
 QueryResult<Object> result = query.execute().get();
 ```
 
-#### Paginating Results
+### Paginating Results
 
 Paginating results can be easily achieved using the `rowsToFetch` parameter when executing a query along with the `fetchMore` API to retrieve more results.
 
@@ -99,7 +99,7 @@ while (!result.getIsDone()) {
 }
 ```
 
-### Pooling
+## Pooling
 
 To streamline the creation and reuse of `SqlJob` objects, your application should establish a connection pool on startup. This is recommended as connection pools significantly improve performance as it reduces the number of connection objects that are created.
 
@@ -112,7 +112,7 @@ Pool pool = new Pool(poolOptions);
 pool.init().get();
 ```
 
-### JDBC Options
+## JDBC Options
 
 When creating an `SqlJob` or `Pool` object, JDBC options can be specified. For a full list of all options, check out the documentation [here](https://www.ibm.com/docs/en/i/7.4?topic=jdbc-toolbox-java-properties).
 
@@ -130,7 +130,7 @@ PoolOptions poolOptions = new PoolOptions(creds, jdbcOptions, 5, 3);
 Pool pool = new Pool(poolOptions);
 ```
 
-### Exception Handling
+## Exception Handling
 
 The APIs provided by the client SDK can throw various checked exceptions which should be caught and handled. In particular, the following exceptions communicate important error information from either the `mapepire-server` component or the client SDK itself:
 
@@ -138,15 +138,15 @@ The APIs provided by the client SDK can throw various checked exceptions which s
 * `UnknownServerException` - This is throw when the server hits an unknown exception.
 * `ClientException` - This is thrown when the client SDK wants to communicate an error with calling an API.
 
-### Secure Connections
+## Secure Connections
 
 By default, Mapepire will always try to connect securely. A majority of the time, servers are using their own self-signed certificate that is not signed by a recognized CA (Certificate Authority). There are two options with the Java client.
 
-#### Allow All Certificates
+### Allow All Certificates
 
 On the `DaemonServer` object, the `ignoreUnauthorized` option can be set to `true` which will allow either self-signed certificates or certificates from a CA.
 
-#### Validate Self-signed Certificates
+### Validate Self-signed Certificates
 
 :::caution
 Validation of self-signed certificates is currently not supported. You can track the progress of this issue [here](https://github.com/Mapepire-IBMi/mapepire-java/issues/49).

--- a/src/content/docs/guides/Usage/java.md
+++ b/src/content/docs/guides/Usage/java.md
@@ -146,7 +146,7 @@ By default, Mapepire will always try to connect securely. A majority of the time
 
 On the `DaemonServer` object, the `ignoreUnauthorized` option can be set to `true` which will allow either self-signed certificates or certificates from a CA.
 
-#### Validate the Self-signed Certificate
+#### Validate Self-signed Certificates
 
 :::caution
 Validation of self-signed certificates is currently not supported. You can track the progress of this issue [here](https://github.com/Mapepire-IBMi/mapepire-java/issues/49).

--- a/src/content/docs/guides/Usage/java.md
+++ b/src/content/docs/guides/Usage/java.md
@@ -1,0 +1,153 @@
+---
+title: Java
+description: Using Mapepire with Java
+sidebar:
+    order: 3
+---
+
+Using DB2 for IBM i with Java is now easy with the help of the `mapepire-java` client SDK. To get started, install the package with `maven`. Make sure to install the latest version from [Maven Central](https://central.sonatype.com/artifact/io.github.mapepire-ibmi/mapepire-sdk).
+
+```xml
+<dependency>
+    <groupId>io.github.mapepire-ibmi</groupId>
+    <artifactId>mapepire-sdk</artifactId>
+    <version>0.0.3</version>  <!-- Use the latest version -->
+</dependency>
+```
+
+## Requirements
+
+* Java 8 or later
+
+### Specifying the `mapepire-server` Instance for the Connection
+
+The location and port of the `mapepire-server` instance as well as the credentials for IBM i Db2 can be specified in a `config.properties` file. Copy the [`config.properties.sample`](https://github.com/Mapepire-IBMi/java/simple-app/src/main/resources/config.properties.sample) file from the `simple-app` demo project to `config.properties` and fill in the credentials.
+
+The following function can be used to construct a `DaemonServer` object with the credentials you just specified. This object will be passed to a `SqlJob` or `Pool` object.
+
+```java
+private static DaemonServer getDaemonServer() throws IOException {
+    // Load config properties
+    Properties properties = new Properties();
+    try (InputStream input = App.class.getClassLoader().getResourceAsStream("config.properties")) {
+        if (input == null) {
+            throw new FileNotFoundException("Unable to find config.properties");
+        }
+        properties.load(input);
+    }
+
+    // Retrieve credentials
+    String host = properties.getProperty("IBMI_HOST");
+    String user = properties.getProperty("IBMI_USER");
+    String password = properties.getProperty("IBMI_PASSWORD");
+    int port = Integer.parseInt(properties.getProperty("IBMI_PORT"));
+
+    return new DaemonServer(host, port, user, password, true, "");
+}
+```
+
+### Running Queries
+
+The core APIs lie in the `SqlJob` and `Query` classes which are what give you the ability to execute queries.
+
+```java
+// Create a single job and connect
+DaemonServer creds = getDaemonServer();
+SqlJob job = new SqlJob();
+job.connect(creds).get();
+
+// Initialize and execute query
+Query<Object> query = job.query("SELECT * FROM SAMPLE.DEPARTMENT");
+QueryResult<Object> result = query.execute(3).get();
+
+// Close query and job
+query.close().get();
+job.close();
+```
+
+#### SQL Prepared Statements 
+
+SQL statements can be easily prepared and executed with parameters:
+
+```java
+QueryOptions options = new QueryOptions(false, false, Arrays.asList("TABLE_NAME", "LONG_COMMENT", "CONSTRAINT_NAME"));
+Query<Object> query = job.query("SELECT * FROM SAMPLE.SYSCOLUMNS WHERE COLUMN_NAME IN (?, ?, ?)", options);
+QueryResult<Object> result = query.execute(30).get();
+```
+
+#### CL Commands
+
+CL commands can be easily run by setting the `isClCommand` option to be `true` on the `QueryOptions` object or by directly using the `clCommand` API on a job:
+
+```java
+Query<Object> query = job.clCommand("CRTLIB LIB(MYLIB1) TEXT('My cool library')");
+QueryResult<Object> result = query.execute().get();
+```
+
+#### Paginating Results
+
+Paginating results can be easily achieved using the `rowsToFetch` parameter when executing a query along with the `fetchMore` API to retrieve more results.
+
+```java
+// Execute query and fetch 10 rows
+Query<Object> query = job.query("SELECT * FROM SAMPLE.DEPARTMENT");
+QueryResult<Object> result = query.execute(10).get();
+
+// Continuously fetch 50 more rows until all all rows have been returned
+while (!result.getIsDone()) {
+    result = query.fetchMore(50).get();
+}
+```
+
+### Pooling
+
+To streamline the creation and reuse of `SqlJob` objects, your application should establish a connection pool on startup. This is recommended as connection pools significantly improve performance as it reduces the number of connection objects that are created.
+
+A pool can be initialized with a given starting size and maximum size. Once initialized, the pool provides APIs to access a free job or to send a query directly to a free job.
+
+```java
+// Create a pool with a max size of 5 and starting size of 3
+PoolOptions poolOptions = new PoolOptions(creds, 5, 3);
+Pool pool = new Pool(poolOptions);
+pool.init().get();
+```
+
+### JDBC Options
+
+When creating an `SqlJob` or `Pool` object, JDBC options can be specified. For a full list of all options, check out the documentation [here](https://www.ibm.com/docs/en/i/7.4?topic=jdbc-toolbox-java-properties).
+
+```java
+// Set JDBC options
+JDBCOptions jdbcOptions = new JDBCOptions();
+jdbcOptions.setNaming(Naming.SQL);
+jdbcOptions.setLibraries(Arrays.asList("MYLIB1", "MYLIB2"));
+
+// Create a single job with JDBC options
+SqlJob job = new SqlJob(jdbcOptions);
+
+// Create a pool with JDBC options
+PoolOptions poolOptions = new PoolOptions(creds, jdbcOptions, 5, 3);
+Pool pool = new Pool(poolOptions);
+```
+
+### Exception Handling
+
+The APIs provided by the client SDK can throw various checked exceptions which should be caught and handled. In particular, the following exceptions communicate important error information from either the `mapepire-server` component or the client SDK itself:
+
+* `SQLException` - This is thrown when an SQL related exception occurs. This will also typically communicate a `reason` and `SQLState`.
+* `UnknownServerException` - This is throw when the server hits an unknown exception.
+* `ClientException` - This is thrown when the client SDK wants to communicate an error with calling an API.
+
+### Secure Connections
+
+By default, Mapepire will always try to connect securely. A majority of the time, servers are using their own self-signed certificate that is not signed by a recognized CA (Certificate Authority). There are two options with the Java client.
+
+#### Allow All Certificates
+
+On the `DaemonServer` object, the `ignoreUnauthorized` option can be set to `true` which will allow either self-signed certificates or certificates from a CA.
+
+#### Validate the Self-signed Certificate
+
+:::caution
+Validation of self-signed certificates is currently not supported. You can track the progress of this issue [here](https://github.com/Mapepire-IBMi/mapepire-java/issues/49).
+:::

--- a/src/content/docs/guides/Usage/nodejs.md
+++ b/src/content/docs/guides/Usage/nodejs.md
@@ -1,6 +1,8 @@
 ---
 title: Node.js
 description: Using Mapepire with Node.js
+sidebar:
+    order: 2
 ---
 
 Using Db2 for IBM i with Node.js is easy. First, install the package:

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ hero:
       icon: right-arrow
       variant: primary
     - text: Pick your client language
-      link: /guides/developer
+      link: /guides/clients
       icon: information
 ---
 
@@ -27,6 +27,6 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 		We created a brand new, simple to manage, database server for IBM i. Run it once, and you're done. [See guide](guides/sysadmin).
 	</Card>
 	<Card title="Install a client library" icon="add-document">
-		Whether you're working in .NET Core, Node.js, or Python, we have a library for you. [See guides](guides/developer).
+		Whether you're working in .NET Core, Node.js, or Python, we have a library for you. [See guides](guides/clients).
 	</Card>
 </CardGrid>


### PR DESCRIPTION
### Changes
- Add Java client docs
- Fix a bunch of links

There are a few references to a `simple-app` project which is going to be a very simple sample project that includes most of the examples mentioned in the docs. Going to PR that project soon.