### PR TITLE
Corrected a typo

### DIFF
--- a/src/content/docs/guides/sysadmin.md
+++ b/src/content/docs/guides/sysadmin.md
@@ -56,7 +56,7 @@ sc start mapepire.yaml
 ## Check it's running
 sc check mapepire.yaml
 
-## Check it's running
+## Stop
 sc stop mapepire.yaml
 
 ## Check it's stopped


### PR DESCRIPTION
Noticed what was likely a copy/paste error in the server install documentation. So I figured I'd fix it.